### PR TITLE
feat: include empty PayFast fields in signature

### DIFF
--- a/buildPfParamString.mjs
+++ b/buildPfParamString.mjs
@@ -10,11 +10,13 @@ function pfEncode(v) {
     .replace(/%[0-9a-f]{2}/g, m => m.toUpperCase()); // uppercase hex
 }
 
-// Build canonical string from ALL non-empty fields except 'signature', preserving insertion order.
+// Build canonical string from all fields except 'signature', preserving insertion order.
+// By default, keys with blank values are excluded. Pass { includeEmpty: true }
+// to retain them as `key=` while still excluding null/undefined.
 // Append passphrase LAST (only if provided).
-export function buildPfParamString(fields, passphrase = '') {
+export function buildPfParamString(fields, passphrase = '', { includeEmpty = false } = {}) {
   const parts = Object.entries(fields)
-    .filter(([k, v]) => k !== 'signature' && v != null && String(v).trim() !== '')
+    .filter(([k, v]) => k !== 'signature' && v != null && (includeEmpty || String(v).trim() !== ''))
     .map(([k, v]) => `${k}=${pfEncode(String(v).trim())}`);
 
   if (passphrase && String(passphrase).trim() !== '') {
@@ -27,8 +29,8 @@ export function md5Hex(s) {
   return crypto.createHash('md5').update(s, 'utf8').digest('hex');
 }
 
-export function generateSignature(fields, passphrase = '') {
-  return md5Hex(buildPfParamString(fields, passphrase));
+export function generateSignature(fields, passphrase = '', opts = {}) {
+  return md5Hex(buildPfParamString(fields, passphrase, opts));
 }
 
 export function buildPfParamStringSorted(fields, passphrase = '') {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   },
 "engines": {
     "node": ">=18"

--- a/server.js
+++ b/server.js
@@ -541,8 +541,8 @@ console.log('ITN payload:', posted);
     }
     // 1) Signature verification (exclude 'signature', passphrase ONLY if set)
     const receivedSig = String(posted.signature || '');
-    const expectedSig = generateSignature(posted, PAYFAST_PASS);
-    console.log('ITN paramString:', buildPfParamString(posted, PAYFAST_PASS));
+    const expectedSig = generateSignature(posted, PAYFAST_PASS, { includeEmpty: true });
+    console.log('ITN paramString:', buildPfParamString(posted, PAYFAST_PASS, { includeEmpty: true }));
     if (process.env.DEBUG_PAYFAST === '1') {
       console.log('ITN paramString(sorted):', buildPfParamStringSortedAll(posted, PAYFAST_PASS));
       console.log('ITN receivedSig:', receivedSig);
@@ -554,7 +554,7 @@ console.log('ITN payload:', posted);
     }
 
     // 2) Validate with PayFast to prevent spoofing (NO passphrase in this call)
-    const qsNoPass = buildPfParamString(posted, '');
+    const qsNoPass = buildPfParamString(posted, '', { includeEmpty: true });
     const validateResp = await validateWithPayFast(qsNoPass);
     if (validateResp !== 'VALID') {
       console.warn('ITN: remote validate != VALID:', validateResp);

--- a/test/itnSignature.test.mjs
+++ b/test/itnSignature.test.mjs
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+
+import { generateSignature } from '../buildPfParamString.mjs';
+
+function pfEncode(v) {
+  return encodeURIComponent(String(v))
+    .replace(/%20/g, '+')
+    .replace(/%[0-9a-f]{2}/g, m => m.toUpperCase());
+}
+
+test('includeEmpty option retains blank fields in signature', () => {
+  const payload = {
+    merchant_id: '10000100',
+    merchant_key: '46f0cd694581a',
+    return_url: 'https://example.com/return',
+    cancel_url: 'https://example.com/cancel',
+    notify_url: 'https://example.com/notify',
+    name_first: 'Test',
+    name_last: 'User',
+    email_address: 'test@example.com',
+    m_payment_id: '1234',
+    amount_gross: '100.00',
+    item_name: 'Test Item',
+    item_description: '',
+    custom_str1: '',
+    signature: 'ignored'
+  };
+  const passphrase = 'mypass';
+
+  const paramString = [
+    `merchant_id=${pfEncode('10000100')}`,
+    `merchant_key=${pfEncode('46f0cd694581a')}`,
+    `return_url=${pfEncode('https://example.com/return')}`,
+    `cancel_url=${pfEncode('https://example.com/cancel')}`,
+    `notify_url=${pfEncode('https://example.com/notify')}`,
+    `name_first=${pfEncode('Test')}`,
+    `name_last=${pfEncode('User')}`,
+    `email_address=${pfEncode('test@example.com')}`,
+    `m_payment_id=${pfEncode('1234')}`,
+    `amount_gross=${pfEncode('100.00')}`,
+    `item_name=${pfEncode('Test Item')}`,
+    `item_description=`,
+    `custom_str1=`,
+    `passphrase=${pfEncode(passphrase)}`
+  ].join('&');
+
+  const expectedSig = crypto.createHash('md5').update(paramString, 'utf8').digest('hex');
+
+  assert.equal(
+    generateSignature(payload, passphrase, { includeEmpty: true }),
+    expectedSig
+  );
+  assert.notEqual(generateSignature(payload, passphrase), expectedSig);
+});


### PR DESCRIPTION
## Summary
- support optional retention of empty fields when building PayFast parameter strings
- ensure ITN handler verifies signatures with blank fields
- add tests for ITN payloads with empty values and npm test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68accdcf022c83259e3ff4fc51cbb3ba