### PR TITLE
Wait for Firebase auth state before gate check

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -43,12 +43,30 @@ async function safeFetchJson(url, opts = {}) {
 // ─── Auth gate on app load ─────────────────────────────────────
 (async function guardAccess() {
   const appEl = document.getElementById('app');
+  const auth = window.__auth;
   try {
-    const headers = new Headers();
-    if (window.__auth?.currentUser) {
-      const t = await window.__auth.currentUser.getIdToken(false);
-      headers.set('Authorization', `Bearer ${t}`);
+    // Wait for Firebase Auth to settle before proceeding
+    if (auth?.authStateReady) {
+      await auth.authStateReady();
+    } else if (auth?.onAuthStateChanged) {
+      await new Promise((resolve) => {
+        const unsub = auth.onAuthStateChanged(() => {
+          unsub();
+          resolve();
+        });
+      });
     }
+
+    const headers = new Headers();
+    const user = auth?.currentUser;
+    if (!user) {
+      // Still not signed in → go to login page file
+      location.href = '/login.html';
+      return;
+    }
+
+    const t = await user.getIdToken(false);
+    headers.set('Authorization', `Bearer ${t}`);
     const r = await fetch('/api/me', { headers });
 
     if (r.ok) {


### PR DESCRIPTION
## Summary
- wait for Firebase auth to settle before verifying access
- redirect to login if auth state remains unauthenticated

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad54dc186c83259ddfb95bce292526