### PR TITLE
Use in-memory auth persistence for login page

### DIFF
--- a/public/login.js
+++ b/public/login.js
@@ -2,7 +2,8 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.4/firebase-app.js";
 import {
   getAuth, onAuthStateChanged,
-  createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut
+  createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut,
+  setPersistence, inMemoryPersistence
 } from "https://www.gstatic.com/firebasejs/10.12.4/firebase-auth.js";
 
 // Firebase config (your project)
@@ -18,6 +19,7 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
+await setPersistence(auth, inMemoryPersistence);
 window.__auth = auth; // let other scripts use token if needed
 
 // ===== helpers =====


### PR DESCRIPTION
## Summary
- ensure Firebase auth uses in-memory persistence on login page so sessions don't survive reloads

## Testing
- `npm test`
- Unable to verify login persistence in-browser due to network restrictions


------
https://chatgpt.com/codex/tasks/task_e_68ad60cf975c8325a5d5087d3ef39fe1