### PR TITLE
Simplify login flow and enforce subscription check

### DIFF
--- a/public/login.js
+++ b/public/login.js
@@ -50,46 +50,13 @@ const emailEl = document.getElementById('email');
 const passEl  = document.getElementById('pass');
 const meBox   = document.getElementById('meBox');
 
-const gateCard    = document.getElementById('gate');
-const gateStatus  = document.getElementById('gateStatus');
-const enterAppBtn = document.getElementById('enterAppBtn');
-const subscribeBtn= document.getElementById('subscribeBtn');
-
-// ===== gate helpers =====
-function showGate({ show, status, canEnter, canSubscribe }){
-  gateCard.style.display = show ? 'block' : 'none';
-  gateStatus.textContent = status || '';
-  enterAppBtn.style.display = canEnter ? 'inline-block' : 'none';
-  subscribeBtn.style.display = canSubscribe ? 'inline-block' : 'none';
-}
-async function refreshGate(){
-  const user = auth.currentUser;
-  if (!user){
-    showGate({ show:true, status:'Please sign in to continue.', canEnter:false, canSubscribe:false });
-    return;
-  }
-  try{
-    const me = await authFetchJson('/api/me');
-    if (me?.subscriber){
-      showGate({ show:true, status:'Subscription active ✅', canEnter:true, canSubscribe:false });
-    }else{
-      showGate({ show:true, status:'Subscription required ❗', canEnter:false, canSubscribe:true });
-    }
-    meBox.textContent = JSON.stringify(me, null, 2);
-  }catch(e){
-    showGate({ show:true, status:'Could not verify subscription.', canEnter:false, canSubscribe:false });
-    meBox.textContent = String(e);
-  }
-}
-
 // ===== auth state =====
-onAuthStateChanged(auth, async (user) => {
+onAuthStateChanged(auth, (user) => {
   if (user) {
     setText('msg', `Signed in as ${user.email}`);
-    await refreshGate();
+    location.href = '/index.html';
   } else {
     setText('msg', 'Not signed in.');
-    showGate({ show:true, status:'Please sign in to continue.', canEnter:false, canSubscribe:false });
   }
 });
 
@@ -103,6 +70,7 @@ document.getElementById('btnSignup').onclick = async () => {
 document.getElementById('btnSignin').onclick = async () => {
   try {
     await signInWithEmailAndPassword(auth, emailEl.value, passEl.value);
+    location.href = '/index.html';
   } catch (e) { alert(e.message || e); }
 };
 document.getElementById('btnSignout').onclick = async () => {
@@ -112,18 +80,4 @@ document.getElementById('btnSignout').onclick = async () => {
 document.getElementById('btnMe').onclick = async () => {
   try { meBox.textContent = JSON.stringify(await authFetchJson('/api/me'), null, 2); }
   catch (e) { meBox.textContent = String(e); }
-};
-
-enterAppBtn.onclick = () => { location.href = '/index.html'; };
-
-subscribeBtn.onclick = async () => {
-  try {
-    const res = await authFetch('/api/payfast/subscribe', { method:'POST' });
-    const html = await res.text();
-    const w = window.open('', '_blank');
-    if (!w) return alert('Please allow popups for this site.');
-    w.document.open(); w.document.write(html); w.document.close(); // autosubmit
-  } catch (e) {
-    alert(e.message || e);
-  }
 };

--- a/public/script.js
+++ b/public/script.js
@@ -75,16 +75,22 @@ async function safeFetchJson(url, opts = {}) {
     headers.set('Authorization', `Bearer ${t}`);
     const r = await fetch('/api/me', { headers });
 
-    if (r.ok) {
-      // Auth OK → reveal app
-      if (appEl) appEl.hidden = false;
-      return;
-    }
     if (r.status === 401) {
-      // Not signed in → go to login page file
       location.href = '/login.html';
       return;
     }
+
+    if (r.ok) {
+      const me = await r.json();
+      if (me?.subscriber) {
+        if (appEl) appEl.hidden = false;
+        return;
+      }
+      // Not subscribed → redirect to subscribe page
+      location.href = '/subscribe.html';
+      return;
+    }
+
     console.error('Gate unexpected:', r.status, await r.text());
   } catch (err) {
     console.error('Gate check failed:', err);

--- a/public/subscribe.html
+++ b/public/subscribe.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Preach Point — Subscribe</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+  <h1>Subscription required</h1>
+  <p>You need an active subscription to access Preach Point.</p>
+  <button id="subscribeBtn">Subscribe — R99 / month</button>
+  <p><a href="/login.html">Return to login</a></p>
+  <script type="module">
+    import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.4/firebase-app.js";
+    import { getAuth, onAuthStateChanged, setPersistence, inMemoryPersistence } from "https://www.gstatic.com/firebasejs/10.12.4/firebase-auth.js";
+
+    const firebaseConfig = {
+      apiKey: "AIzaSyB6mjVxBIW8d2dMD6jRe9MD257qsNC2Ia0",
+      authDomain: "preach-point.firebaseapp.com",
+      projectId: "preach-point",
+      storageBucket: "preach-point.firebasestorage.app",
+      messagingSenderId: "699269130347",
+      appId: "1:699269130347:web:a6617996b042821089692e",
+      measurementId: "G-3L6CZ43J51"
+    };
+
+    const app = initializeApp(firebaseConfig);
+    const auth = getAuth(app);
+    await setPersistence(auth, inMemoryPersistence);
+
+    onAuthStateChanged(auth, async (user) => {
+      if (!user) {
+        location.href = '/login.html';
+      }
+    });
+
+    document.getElementById('subscribeBtn').onclick = async () => {
+      try {
+        const t = await auth.currentUser.getIdToken(true);
+        const res = await fetch('/api/payfast/subscribe', {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${t}` }
+        });
+        const html = await res.text();
+        const w = window.open('', '_blank');
+        if (!w) return alert('Please allow popups for this site.');
+        w.document.open(); w.document.write(html); w.document.close();
+      } catch (e) {
+        alert(e.message || e);
+      }
+    };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Remove complex gating from login.js and redirect to index on sign-in
- Guard app access by checking subscriber status and sending unsubscribed users to a dedicated page
- Add standalone subscription page for upgrading accounts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad6cb001c08325b04c3a5eb93598ca