### PR TITLE
feat: keep signed-in users on login page

### DIFF
--- a/public/login.js
+++ b/public/login.js
@@ -33,7 +33,11 @@ const passEl  = document.getElementById('pass');
 // ===== auth state =====
 onAuthStateChanged(auth, (user) => {
   if (user) {
-    location.href = '/index.html';
+    // Stay on the login page, but let the user enter the app if desired
+    const el = document.getElementById('msg');
+    if (el) {
+      el.innerHTML = "You're already signed in. <a href='/index.html'>Enter App</a>";
+    }
   } else {
     setText('msg', 'Not signed in.');
   }


### PR DESCRIPTION
## Summary
- allow logged-in users to stay on login page and offer "Enter App" link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad78ce7c708325b19449804c0bc634