### PR TITLE
Simplify subscription result pages

### DIFF
--- a/public/subscribe/cancel.html
+++ b/public/subscribe/cancel.html
@@ -14,7 +14,7 @@
 
     <h1>Payment cancelled</h1>
     <p>No charge was made. You can try again anytime.</p>
-    <p><a href="/">Back to Preach Point</a></p>
+    <button onclick="location.href='/'">Back to Preach Point</button>
   </div>
 </body>
 </html>

--- a/public/subscribe/success.html
+++ b/public/subscribe/success.html
@@ -13,32 +13,8 @@
     </header>
 
     <h1>Thank you!</h1>
-    <p>Your payment was received. We’re confirming your subscription…</p>
-    <p id="status">Checking status…</p>
-    <p><a href="/">Back to Preach Point</a></p>
+    <p>Your payment was received.</p>
+    <button onclick="location.href='/'">Back to Preach Point</button>
   </div>
-
-  <script>
-    // Poll /api/me for subscriber flag (ITN flips it on the server)
-    (async function poll() {
-      try {
-        const headers = new Headers();
-        if (window.opener && window.opener.__auth?.currentUser) {
-          const t = await window.opener.__auth.currentUser.getIdToken();
-          headers.set('Authorization', 'Bearer ' + t);
-        }
-        const r = await fetch('/api/me', { headers });
-        const txt = await r.text();
-        if (r.ok) {
-          const me = JSON.parse(txt);
-          if (me.subscriber) {
-            document.getElementById('status').textContent = 'Subscription is ACTIVE. You can return to the app.';
-            return;
-          }
-        }
-      } catch (e) {}
-      setTimeout(poll, 2000);
-    })();
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Streamline subscription success page to display only payment confirmation
- Style cancellation page like success page and use button for navigation
- Remove subscription status polling script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adbada35dc832580363b90a89ce089