### PR TITLE
Simplify subscription result pages

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -424,7 +424,7 @@ async function onGenerate() {
     return; // stop further steps if verses fail
   }
 
-  // 2) Commentary (protected)
+  // 2) Commentary
   try {
     const js2 = await safeFetchJson('/api/commentary', {
       method: 'POST',
@@ -440,7 +440,7 @@ async function onGenerate() {
     $('commentary').textContent = `Error: ${e.message}`;
   }
 
-  // 3) Devotion (protected)
+  // 3) Devotion
   try {
     const jsD = await safeFetchJson('/api/devotion', {
       method: 'POST',
@@ -452,7 +452,7 @@ async function onGenerate() {
     $('devotionOutput').textContent = `Error: ${e.message}`;
   }
 
-  // 4) Prayer (protected)
+  // 4) Prayer
   try {
     const js3 = await safeFetchJson('/api/prayer', {
       method: 'POST',

--- a/public/subscribe/cancel.html
+++ b/public/subscribe/cancel.html
@@ -14,7 +14,7 @@
 
     <h1>Payment cancelled</h1>
     <p>No charge was made. You can try again anytime.</p>
-    <p><a href="/">Back to Preach Point</a></p>
+    <button onclick="location.href='/'">Back to Preach Point</button>
   </div>
 </body>
 </html>

--- a/public/subscribe/success.html
+++ b/public/subscribe/success.html
@@ -13,32 +13,8 @@
     </header>
 
     <h1>Thank you!</h1>
-    <p>Your payment was received. We’re confirming your subscription…</p>
-    <p id="status">Checking status…</p>
-    <p><a href="/">Back to Preach Point</a></p>
+    <p>Your payment was received.</p>
+    <button onclick="location.href='/'">Back to Preach Point</button>
   </div>
-
-  <script>
-    // Poll /api/me for subscriber flag (ITN flips it on the server)
-    (async function poll() {
-      try {
-        const headers = new Headers();
-        if (window.opener && window.opener.__auth?.currentUser) {
-          const t = await window.opener.__auth.currentUser.getIdToken();
-          headers.set('Authorization', 'Bearer ' + t);
-        }
-        const r = await fetch('/api/me', { headers });
-        const txt = await r.text();
-        if (r.ok) {
-          const me = JSON.parse(txt);
-          if (me.subscriber) {
-            document.getElementById('status').textContent = 'Subscription is ACTIVE. You can return to the app.';
-            return;
-          }
-        }
-      } catch (e) {}
-      setTimeout(poll, 2000);
-    })();
-  </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -711,7 +711,7 @@ app.post('/api/translate', async (req, res) => {
   }
 });
 // 9️⃣ Endpoint: AI-only commentary
-app.post('/api/commentary', requireAuth, requireSubscriberDb, async (req, res) => {
+app.post('/api/commentary', async (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse, tone, level, lang } = req.body;
     if (!book || !startChapter || !startVerse) {
@@ -752,7 +752,7 @@ const passageRef = `${afRefBook} ${startChapter}:${startVerse}-${endChapter || s
   }
 });
 // 9.5️⃣ Endpoint: AI-only devotion
-app.post('/api/devotion',  requireAuth, requireSubscriberDb, async (req, res) => {
+app.post('/api/devotion',  async (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse, lang } = req.body;
     if (!book || !startChapter || !startVerse) {
@@ -801,7 +801,7 @@ ${scripture}`;
 
 
 // 🔟 Endpoint: AI-only prayer
-app.post('/api/prayer',    requireAuth, requireSubscriberDb, async (req, res) => {
+app.post('/api/prayer',    async (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse, lang } = req.body;
     if (!book || !startChapter || !startVerse) {


### PR DESCRIPTION
## Summary
- Streamline subscription success page to display only payment confirmation
- Style cancellation page like success page and use button for navigation
- Remove subscription status polling script
- Allow commentary, devotion, and prayer endpoints to run without authentication

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adbada35dc832580363b90a89ce089