### PR TITLE
Simplify subscription result pages and standardize pop-ups

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="style.css"/>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script defer src="popup.js"></script>
   <script defer src="script.js"></script>
 </head>
 <link rel="icon" type="image/png" href="/favicon.png">

--- a/public/login.html
+++ b/public/login.html
@@ -100,6 +100,7 @@
   </div>
 
   <!-- App logic (gating + subscribe flow) -->
+  <script src="/popup.js"></script>
   <script type="module" src="/login.js"></script>
 </body>
 </html>

--- a/public/login.js
+++ b/public/login.js
@@ -47,9 +47,14 @@ onAuthStateChanged(auth, (user) => {
 document.getElementById('btnSignup').onclick = async () => {
   try {
     await createUserWithEmailAndPassword(auth, emailEl.value, passEl.value);
-    alert('Account created & signed in. You must complete payment before accessing the app.');
+    ppAlert('Account created & signed in. You must complete payment before accessing the app.');
     location.href = '/subscribe.html';
-  } catch (e) { alert(e.message || e); }
+  } catch (e) {
+    const msg = e.code === 'auth/email-already-in-use'
+      ? 'Email already in use'
+      : (e.message || e);
+    ppAlert(msg);
+  }
 };
 document.getElementById('btnSignin').onclick = async () => {
   try {
@@ -59,10 +64,10 @@ document.getElementById('btnSignin').onclick = async () => {
     const msg = e.code === 'auth/invalid-credential'
       ? 'User not Subscribed. Please create account'
       : (e.message || e);
-    alert(msg);
+    ppAlert(msg);
   }
 };
 document.getElementById('btnSignout').onclick = async () => {
   await signOut(auth);
-  alert('Signed out.');
+  ppAlert('Signed out.');
 };

--- a/public/popup.js
+++ b/public/popup.js
@@ -1,0 +1,29 @@
+(function(){
+  const style = document.createElement('style');
+  style.textContent = `
+.pp-alert-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:9999;}
+.pp-alert{background:#fff;color:#1a1a1a;padding:20px;border-radius:10px;max-width:90%;min-width:260px;text-align:center;font-family:'Helvetica Neue',Arial,sans-serif;box-shadow:0 4px 10px rgba(0,0,0,.3);}
+.pp-alert-title{margin:0 0 10px;font-size:18px;font-weight:bold;color:#6B1A7B;}
+.pp-alert button{margin-top:15px;}
+`;
+  document.head.appendChild(style);
+
+  window.ppAlert = function(message){
+    const overlay = document.createElement('div');
+    overlay.className = 'pp-alert-overlay';
+    const box = document.createElement('div');
+    box.className = 'pp-alert';
+    const title = document.createElement('div');
+    title.className = 'pp-alert-title';
+    title.textContent = 'Preach Point says';
+    const body = document.createElement('div');
+    body.textContent = message;
+    const btn = document.createElement('button');
+    btn.textContent = 'OK';
+    btn.onclick = () => overlay.remove();
+    box.append(title, body, btn);
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
+    btn.focus();
+  };
+})();

--- a/public/script.js
+++ b/public/script.js
@@ -189,7 +189,7 @@ async function populateChapters() {
   try {
     js = await safeFetchJson(`/api/chapters?book=${encodeURIComponent(bookName)}`);
   } catch (err) {
-    alert(`Could not load chapters: ${err.message}`);
+    ppAlert(`Could not load chapters: ${err.message}`);
     return;
   }
 
@@ -220,7 +220,7 @@ async function populateVerses() {
       `/api/versesCount?book=${encodeURIComponent(bookName)}&chapter=${chap}`
     );
   } catch (err) {
-    alert(`Could not load verses: ${err.message}`);
+    ppAlert(`Could not load verses: ${err.message}`);
     return;
   }
 
@@ -247,7 +247,7 @@ async function populateEndVerses() {
       `/api/versesCount?book=${encodeURIComponent(bookName)}&chapter=${endChap}`
     );
   } catch (err) {
-    alert(`Could not load verses: ${err.message}`);
+    ppAlert(`Could not load verses: ${err.message}`);
     return;
   }
 
@@ -345,7 +345,7 @@ async function onGenerate() {
   const lvl      = $('level').value;
 
   if (!bookName || !sCh || !sV) {
-    alert('Please select a book, chapter & verse.');
+    ppAlert('Please select a book, chapter & verse.');
     return;
   }
 
@@ -398,7 +398,7 @@ async function onGenerate() {
 
     const maxLimit = 50;
     if (totalVerses > maxLimit) {
-      alert(`Please limit your selection to ${maxLimit} verses. You selected ${totalVerses}.`);
+      ppAlert(`Please limit your selection to ${maxLimit} verses. You selected ${totalVerses}.`);
       return;
     }
   } catch (e) {
@@ -424,7 +424,7 @@ async function onGenerate() {
     return; // stop further steps if verses fail
   }
 
-  // 2) Commentary (protected)
+  // 2) Commentary
   try {
     const js2 = await safeFetchJson('/api/commentary', {
       method: 'POST',
@@ -440,7 +440,7 @@ async function onGenerate() {
     $('commentary').textContent = `Error: ${e.message}`;
   }
 
-  // 3) Devotion (protected)
+  // 3) Devotion
   try {
     const jsD = await safeFetchJson('/api/devotion', {
       method: 'POST',
@@ -452,7 +452,7 @@ async function onGenerate() {
     $('devotionOutput').textContent = `Error: ${e.message}`;
   }
 
-  // 4) Prayer (protected)
+  // 4) Prayer
   try {
     const js3 = await safeFetchJson('/api/prayer', {
       method: 'POST',

--- a/public/subscribe.html
+++ b/public/subscribe.html
@@ -19,6 +19,7 @@
       <button id="loginBtn">Return to login</button>
     </div>
   </div>
+  <script src="popup.js"></script>
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.4/firebase-app.js";
     import { getAuth, onAuthStateChanged, setPersistence, browserLocalPersistence } from "https://www.gstatic.com/firebasejs/10.12.4/firebase-auth.js";
@@ -56,10 +57,10 @@
         });
         const html = await res.text();
         const w = window.open('', '_blank');
-        if (!w) return alert('Please allow popups for this site.');
+        if (!w) return ppAlert('Please allow popups for this site.');
         w.document.open(); w.document.write(html); w.document.close();
       } catch (e) {
-        alert(e.message || e);
+        ppAlert(e.message || e);
       }
     };
   </script>

--- a/public/subscribe/cancel.html
+++ b/public/subscribe/cancel.html
@@ -14,7 +14,7 @@
 
     <h1>Payment cancelled</h1>
     <p>No charge was made. You can try again anytime.</p>
-    <p><a href="/">Back to Preach Point</a></p>
+    <button onclick="location.href='/'">Back to Preach Point</button>
   </div>
 </body>
 </html>

--- a/public/subscribe/success.html
+++ b/public/subscribe/success.html
@@ -13,32 +13,8 @@
     </header>
 
     <h1>Thank you!</h1>
-    <p>Your payment was received. We’re confirming your subscription…</p>
-    <p id="status">Checking status…</p>
-    <p><a href="/">Back to Preach Point</a></p>
+    <p>Your payment was received.</p>
+    <button onclick="location.href='/'">Back to Preach Point</button>
   </div>
-
-  <script>
-    // Poll /api/me for subscriber flag (ITN flips it on the server)
-    (async function poll() {
-      try {
-        const headers = new Headers();
-        if (window.opener && window.opener.__auth?.currentUser) {
-          const t = await window.opener.__auth.currentUser.getIdToken();
-          headers.set('Authorization', 'Bearer ' + t);
-        }
-        const r = await fetch('/api/me', { headers });
-        const txt = await r.text();
-        if (r.ok) {
-          const me = JSON.parse(txt);
-          if (me.subscriber) {
-            document.getElementById('status').textContent = 'Subscription is ACTIVE. You can return to the app.';
-            return;
-          }
-        }
-      } catch (e) {}
-      setTimeout(poll, 2000);
-    })();
-  </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -711,7 +711,7 @@ app.post('/api/translate', async (req, res) => {
   }
 });
 // 9️⃣ Endpoint: AI-only commentary
-app.post('/api/commentary', requireAuth, requireSubscriberDb, async (req, res) => {
+app.post('/api/commentary', async (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse, tone, level, lang } = req.body;
     if (!book || !startChapter || !startVerse) {
@@ -752,7 +752,7 @@ const passageRef = `${afRefBook} ${startChapter}:${startVerse}-${endChapter || s
   }
 });
 // 9.5️⃣ Endpoint: AI-only devotion
-app.post('/api/devotion',  requireAuth, requireSubscriberDb, async (req, res) => {
+app.post('/api/devotion',  async (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse, lang } = req.body;
     if (!book || !startChapter || !startVerse) {
@@ -801,7 +801,7 @@ ${scripture}`;
 
 
 // 🔟 Endpoint: AI-only prayer
-app.post('/api/prayer',    requireAuth, requireSubscriberDb, async (req, res) => {
+app.post('/api/prayer',    async (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse, lang } = req.body;
     if (!book || !startChapter || !startVerse) {


### PR DESCRIPTION
## Summary
- Streamline subscription success page to display only payment confirmation
- Style cancellation page like success page and use button for navigation
- Remove subscription status polling script
- Allow commentary, devotion, and prayer endpoints to run without authentication
- Replace browser alerts with styled "Preach Point says" modal and show friendly email duplication error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adbada35dc832580363b90a89ce089