### PR TITLE
Use Firebase signOut for logout

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -326,7 +326,8 @@ function onReset() {
 }
 
 async function onLogout() {
-  await window.__auth.signOut();
+  const { signOut } = await import('https://www.gstatic.com/firebasejs/10.12.4/firebase-auth.js');
+  await signOut(window.__auth);
   location.href = '/login.html';
 }
 // ─── Wire up event listeners ─────────────────────────────────────


### PR DESCRIPTION
## Summary
- dynamically import Firebase auth's signOut in logout handler
- ensure logout button registers onLogout handler

## Testing
- `npm test`
- `npm start` *(fails: No service account provided. Admin-only routes will be limited. Missing OpenAI key!)*

------
https://chatgpt.com/codex/tasks/task_e_68ade2d1d0088325a2e54a02dffce8ce