### PR TITLE
Add trial period support and delay billing

### DIFF
--- a/public/login.js
+++ b/public/login.js
@@ -31,9 +31,8 @@ const emailEl = document.getElementById('email');
 const passEl  = document.getElementById('pass');
 
 // ===== auth state =====
-onAuthStateChanged(auth, (user) => {
+onAuthStateChanged(auth, async (user) => {
   if (user) {
-    // Stay on the login page, but let the user enter the app if desired
     const el = document.getElementById('msg');
     if (el) {
       el.textContent = "You're already signed in.";
@@ -42,6 +41,23 @@ onAuthStateChanged(auth, (user) => {
       btn.textContent = 'Enter App';
       btn.onclick = () => location.href = '/index.html';
       el.appendChild(btn);
+
+      // Show trial info if available
+      try {
+        const t = await user.getIdToken(false);
+        const r = await fetch('/api/me', { headers: { Authorization: `Bearer ${t}` } });
+        if (r.ok) {
+          const me = await r.json();
+          if (me.trialActive && me.trialEnds) {
+            const days = Math.ceil((new Date(me.trialEnds).getTime() - Date.now()) / (1000*60*60*24));
+            const p = document.createElement('p');
+            p.textContent = `Trial: ${days} day${days !== 1 ? 's' : ''} remaining`;
+            el.appendChild(p);
+          }
+        }
+      } catch (err) {
+        console.warn('fetch /api/me failed', err);
+      }
     }
   } else {
     setText('msg', 'Not signed in.');
@@ -52,8 +68,14 @@ onAuthStateChanged(auth, (user) => {
 document.getElementById('btnSignup').onclick = async () => {
   try {
     await createUserWithEmailAndPassword(auth, emailEl.value, passEl.value);
-    ppAlert('Account created & signed in. You must complete payment before accessing the app.');
-    location.href = '/subscribe.html';
+    try {
+      const t = await auth.currentUser.getIdToken(false);
+      await fetch('/api/trial', { method: 'POST', headers: { Authorization: `Bearer ${t}` } });
+    } catch (err) {
+      console.warn('Could not start trial:', err);
+    }
+    ppAlert('Account created & signed in. Your free trial has started.');
+    location.href = '/index.html';
   } catch (e) {
     const msg = e.code === 'auth/email-already-in-use'
       ? 'Email already in use'

--- a/public/script.js
+++ b/public/script.js
@@ -82,11 +82,10 @@ async function safeFetchJson(url, opts = {}) {
 
     if (r.ok) {
       const me = await r.json();
-      if (me?.subscriber) {
+      if (me?.subscriber || me?.trialActive) {
         if (appEl) appEl.hidden = false;
         return;
       }
-      // Not subscribed → redirect to subscribe page
       location.href = '/subscribe.html';
       return;
     }

--- a/server.js
+++ b/server.js
@@ -136,15 +136,25 @@ function requireAuth(req, res, next) {
   if (!req.user?.uid) return res.status(401).json({ error: 'Sign in required' });
   next();
 }
-async function requireSubscriberDb(req, res, next) {
+
+// Allow access if the user is a subscriber OR has an active trial
+async function requireSubOrTrial(req, res, next) {
   if (!req.user?.uid) return res.status(401).json({ error: 'Sign in required' });
   try {
     const snap = await db.doc(`users/${req.user.uid}`).get();
-    if (snap.exists && !!snap.data()?.subscriber) return next();
+    if (snap.exists) {
+      const data = snap.data() || {};
+      const subscriber = !!data.subscriber;
+      const trialEnd = data.trialEnds instanceof admin.firestore.Timestamp
+        ? data.trialEnds.toDate()
+        : data.trialEnds ? new Date(data.trialEnds) : null;
+      const trialActive = trialEnd && trialEnd.getTime() > Date.now();
+      if (subscriber || trialActive) return next();
+    }
   } catch (e) {
-    console.warn('requireSubscriberDb read failed:', e.message);
+    console.warn('requireSubOrTrial read failed:', e.message);
   }
-  return res.status(402).json({ error: 'Subscription required' });
+  return res.status(402).json({ error: 'Subscription or trial required' });
 }
 
 app.use(authOptional);
@@ -164,16 +174,55 @@ app.get('/api/me', requireAuth, async (req, res) => {
   res.set('Expires', '0');
   const { uid, email } = req.user || {};
   let subscriber = false;
+  let trialEnds = null;
+  let trialActive = false;
 
   try {
-    // use your existing Firestore instance (db)
     const snap = await db.doc(`users/${uid}`).get();
-    if (snap.exists) subscriber = !!snap.data()?.subscriber;
+    if (snap.exists) {
+      const data = snap.data() || {};
+      subscriber = !!data.subscriber;
+      if (data.trialEnds instanceof admin.firestore.Timestamp) {
+        trialEnds = data.trialEnds.toDate();
+      } else if (data.trialEnds) {
+        trialEnds = new Date(data.trialEnds);
+      }
+      if (trialEnds) trialActive = trialEnds.getTime() > Date.now();
+    }
   } catch (e) {
     console.warn('me: firestore read failed', e.message);
   }
 
-  res.json({ uid, email, subscriber });
+  res.json({
+    uid,
+    email,
+    subscriber,
+    trialEnds: trialEnds ? trialEnds.toISOString() : null,
+    trialActive
+  });
+});
+
+// Set up a 7-day trial for the signed-in user (if not already present)
+app.post('/api/trial', requireAuth, async (req, res) => {
+  try {
+    const { uid } = req.user;
+    const ref = db.doc(`users/${uid}`);
+    const snap = await ref.get();
+    let trialEnds;
+    if (snap.exists && snap.data()?.trialEnds) {
+      const existing = snap.data().trialEnds;
+      trialEnds = existing instanceof admin.firestore.Timestamp ? existing.toDate() : new Date(existing);
+    } else {
+      const now = admin.firestore.Timestamp.now();
+      const endTs = admin.firestore.Timestamp.fromMillis(now.toMillis() + 7 * 24 * 60 * 60 * 1000);
+      await ref.set({ trialEnds: endTs }, { merge: true });
+      trialEnds = endTs.toDate();
+    }
+    res.json({ trialEnds: trialEnds.toISOString(), trialActive: trialEnds.getTime() > Date.now() });
+  } catch (e) {
+    console.error('trial start failed:', e);
+    res.status(500).json({ error: e.message || 'Could not start trial' });
+  }
 });
 
 // ---- DEBUG: show masked PayFast/Firebase envs (no secrets) --------------------
@@ -475,7 +524,7 @@ app.post('/api/payfast/subscribe', requireAuth, async (req, res) => {
       item_name: 'Preach Point Monthly',
       custom_str1: uid,
       subscription_type: '1',
-      billing_date: new Date(Date.now() + 24*60*60*1000).toISOString().slice(0,10),
+        billing_date: new Date(Date.now() + 7*24*60*60*1000).toISOString().slice(0,10),
 
       recurring_amount: price,
       frequency: '3', // monthly
@@ -665,7 +714,7 @@ app.get('/api/versesCount', (req, res) => {
 });
 
 // 7️⃣ Endpoint: fetch bible text (single or multi-chapter)
-app.post('/api/verses', (req, res) => {
+app.post('/api/verses', requireSubOrTrial, (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse } = req.body;
     if (!book || !startChapter || !startVerse) {
@@ -685,7 +734,7 @@ app.post('/api/verses', (req, res) => {
 });
 
 // 8️⃣ Endpoint: translate into Afrikaans
-app.post('/api/translate', async (req, res) => {
+app.post('/api/translate', requireSubOrTrial, async (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse } = req.body;
     if (!book || !startChapter || !startVerse) {
@@ -711,7 +760,7 @@ app.post('/api/translate', async (req, res) => {
   }
 });
 // 9️⃣ Endpoint: AI-only commentary
-app.post('/api/commentary', async (req, res) => {
+app.post('/api/commentary', requireSubOrTrial, async (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse, tone, level, lang } = req.body;
     if (!book || !startChapter || !startVerse) {
@@ -752,7 +801,7 @@ const passageRef = `${afRefBook} ${startChapter}:${startVerse}-${endChapter || s
   }
 });
 // 9.5️⃣ Endpoint: AI-only devotion
-app.post('/api/devotion',  async (req, res) => {
+app.post('/api/devotion',  requireSubOrTrial, async (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse, lang } = req.body;
     if (!book || !startChapter || !startVerse) {
@@ -801,7 +850,7 @@ ${scripture}`;
 
 
 // 🔟 Endpoint: AI-only prayer
-app.post('/api/prayer',    async (req, res) => {
+app.post('/api/prayer',    requireSubOrTrial, async (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse, lang } = req.body;
     if (!book || !startChapter || !startVerse) {


### PR DESCRIPTION
## Summary
- add `requireSubOrTrial` middleware to allow access for subscribers or active trials
- expose `trialEnds` and `trialActive` via `/api/me` and add endpoint to start a 7‑day trial
- start trial on signup, gate client access by `trialActive`, and delay PayFast billing by one week

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aed355252c8325b76ad8c73f4d7663