### PR TITLE
Redirect signup to subscribe and clarify billing message

### DIFF
--- a/public/login.js
+++ b/public/login.js
@@ -74,8 +74,8 @@ document.getElementById('btnSignup').onclick = async () => {
     } catch (err) {
       console.warn('Could not start trial:', err);
     }
-    ppAlert('Account created & signed in. Your free trial has started.');
-    location.href = '/index.html';
+    ppAlert('Account created & signed in. Your free trial has started. Billing begins after the 7-day trial.');
+    location.href = '/subscribe.html';
   } catch (e) {
     const msg = e.code === 'auth/email-already-in-use'
       ? 'Email already in use'


### PR DESCRIPTION
## Summary
- Redirect new signups to the subscription page after starting a trial
- Clarify in alert that billing begins only after the 7-day trial

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aed8ac41648325b7128ac793040244