### PR TITLE
Allow PayFast form submissions

### DIFF
--- a/server.js
+++ b/server.js
@@ -98,7 +98,11 @@ app.use(helmet({
         "https://*.firebaseio.com"
       ],
       frameSrc:   ["https://www.payfast.co.za"],
-      formAction: ["'self'", "https://www.payfast.co.za"]
+      formAction: [
+        "'self'",
+        "https://www.payfast.co.za/eng/process",
+        "https://sandbox.payfast.co.za/eng/process"
+      ]
     }
   },
   crossOriginEmbedderPolicy: false

--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.gstatic.com https://www.googletagmanager.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.vercel.app https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firestore.googleapis.com https://firebaseinstallations.googleapis.com https://firebasestorage.googleapis.com https://www.googleapis.com https://*.googleapis.com https://www.payfast.co.za; frame-ancestors 'self'; base-uri 'self'; form-action 'self' https://www.payfast.co.za;"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.gstatic.com https://www.googletagmanager.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.vercel.app https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firestore.googleapis.com https://firebaseinstallations.googleapis.com https://firebasestorage.googleapis.com https://www.googleapis.com https://*.googleapis.com https://www.payfast.co.za; frame-ancestors 'self'; base-uri 'self'; form-action 'self' https://www.payfast.co.za/eng/process https://sandbox.payfast.co.za/eng/process;"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- extend Helmet CSP formAction to allow PayFast `eng/process` and sandbox endpoints
- mirror PayFast form-action settings in `vercel.json`

## Testing
- `npm test`
- `curl -I http://localhost:3000`

------
https://chatgpt.com/codex/tasks/task_e_68aedd184e448325b0bb9d9361fd1425