### PR TITLE
Disable Helmet CSP to rely on Vercel config

### DIFF
--- a/server.js
+++ b/server.js
@@ -76,35 +76,9 @@ if (sa) {
 // ─── App setup (create app ONCE, then middlewares) ────────────────────────────
 const app = express();
 
-// CSP/headers (fixes the “default-src 'none'” font issue locally)
+// CSP/headers handled by Vercel (see vercel.json)
 app.use(helmet({
-  contentSecurityPolicy: {
-    directives: {
-      defaultSrc: ["'self'"],
-      scriptSrc:  ["'self'", "https://www.gstatic.com", "https://www.googletagmanager.com", "https://cdnjs.cloudflare.com"],
-      styleSrc:   ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
-      fontSrc:    ["'self'", "https://fonts.gstatic.com", "data:"],
-      imgSrc:     ["'self'", "data:", "https://*"],
-      // 👇 allow Firebase Auth + related endpoints
-      connectSrc: [
-        "'self'",
-        "https://preach-point-login.vercel.app",
-        "https://www.payfast.co.za",
-        "https://identitytoolkit.googleapis.com",
-        "https://securetoken.googleapis.com",
-        "https://www.googleapis.com",
-        "https://firebaseinstallations.googleapis.com",
-        "https://firestore.googleapis.com",
-        "https://*.firebaseio.com"
-      ],
-      frameSrc:   ["https://www.payfast.co.za"],
-      formAction: [
-        "'self'",
-        "https://www.payfast.co.za/eng/process",
-        "https://sandbox.payfast.co.za/eng/process"
-      ]
-    }
-  },
+  contentSecurityPolicy: false,
   crossOriginEmbedderPolicy: false
 }));
 


### PR DESCRIPTION
## Summary
- Remove Helmet Content Security Policy so Vercel headers supply CSP

## Testing
- `npm test`
- `curl -I http://localhost:3000/` (server started with dummy OPENAI_KEY)

------
https://chatgpt.com/codex/tasks/task_e_68aef470f6dc83258fb0532f2d4f96d9