### PR TITLE
Update PayFast CSP form-action directives

### DIFF
--- a/server.js
+++ b/server.js
@@ -100,8 +100,8 @@ app.use(helmet({
       frameSrc:   ["https://www.payfast.co.za"],
       formAction: [
         "'self'",
-        "https://www.payfast.co.za/eng/process",
-        "https://sandbox.payfast.co.za/eng/process"
+        "https://www.payfast.co.za",
+        "https://sandbox.payfast.co.za"
       ]
     }
   },

--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.gstatic.com https://www.googletagmanager.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.vercel.app https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firestore.googleapis.com https://firebaseinstallations.googleapis.com https://firebasestorage.googleapis.com https://www.googleapis.com https://*.googleapis.com https://www.payfast.co.za; frame-ancestors 'self'; base-uri 'self'; form-action 'self' https://www.payfast.co.za/eng/process https://sandbox.payfast.co.za/eng/process;"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.gstatic.com https://www.googletagmanager.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.vercel.app https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firestore.googleapis.com https://firebaseinstallations.googleapis.com https://firebasestorage.googleapis.com https://www.googleapis.com https://*.googleapis.com https://www.payfast.co.za; frame-ancestors 'self'; base-uri 'self'; form-action 'self' https://www.payfast.co.za https://sandbox.payfast.co.za;"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Allow PayFast sandbox and live hosts in Helmet form-action directives
- Sync Vercel CSP header to permit PayFast form submissions without /eng/process

## Testing
- `npm test`
- `curl -I http://localhost:3000/`

------
https://chatgpt.com/codex/tasks/task_e_68aef47c4d1c83258ce71ae975bdd74f