### PR TITLE
Include PayFast sandbox in CSP formAction

### DIFF
--- a/server.js
+++ b/server.js
@@ -78,7 +78,33 @@ const app = express();
 
 // CSP/headers handled by Vercel (see vercel.json)
 app.use(helmet({
-  contentSecurityPolicy: false,
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc:  ["'self'", "https://www.gstatic.com", "https://www.googletagmanager.com", "https://cdnjs.cloudflare.com"],
+      styleSrc:   ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+      fontSrc:    ["'self'", "https://fonts.gstatic.com", "data:"],
+      imgSrc:     ["'self'", "data:", "https://*"],
+      // 👇 allow Firebase Auth + related endpoints
+      connectSrc: [
+        "'self'",
+        "https://preach-point-login.vercel.app",
+        "https://www.payfast.co.za",
+        "https://identitytoolkit.googleapis.com",
+        "https://securetoken.googleapis.com",
+        "https://www.googleapis.com",
+        "https://firebaseinstallations.googleapis.com",
+        "https://firestore.googleapis.com",
+        "https://*.firebaseio.com"
+      ],
+      frameSrc:   ["https://www.payfast.co.za"],
+      formAction: [
+        "'self'",
+        "https://www.payfast.co.za/eng/process",
+        "https://sandbox.payfast.co.za/eng/process"
+      ]
+    }
+  },
   crossOriginEmbedderPolicy: false
 }));
 


### PR DESCRIPTION
## Summary
- restore Helmet CSP directives and allow PayFast form submissions from sandbox and live domains
- restrict PayFast submissions to the PayFast process endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aefa87ebd88325abe911dd9f5f5522