### PR TITLE
Remove trial logic and require subscription

### DIFF
--- a/public/login.js
+++ b/public/login.js
@@ -41,23 +41,6 @@ onAuthStateChanged(auth, async (user) => {
       btn.textContent = 'Enter App';
       btn.onclick = () => location.href = '/index.html';
       el.appendChild(btn);
-
-      // Show trial info if available
-      try {
-        const t = await user.getIdToken(false);
-        const r = await fetch('/api/me', { headers: { Authorization: `Bearer ${t}` } });
-        if (r.ok) {
-          const me = await r.json();
-          if (me.trialActive && me.trialEnds) {
-            const days = Math.ceil((new Date(me.trialEnds).getTime() - Date.now()) / (1000*60*60*24));
-            const p = document.createElement('p');
-            p.textContent = `Trial: ${days} day${days !== 1 ? 's' : ''} remaining`;
-            el.appendChild(p);
-          }
-        }
-      } catch (err) {
-        console.warn('fetch /api/me failed', err);
-      }
     }
   } else {
     setText('msg', 'Not signed in.');
@@ -68,13 +51,7 @@ onAuthStateChanged(auth, async (user) => {
 document.getElementById('btnSignup').onclick = async () => {
   try {
     await createUserWithEmailAndPassword(auth, emailEl.value, passEl.value);
-    try {
-      const t = await auth.currentUser.getIdToken(false);
-      await fetch('/api/trial', { method: 'POST', headers: { Authorization: `Bearer ${t}` } });
-    } catch (err) {
-      console.warn('Could not start trial:', err);
-    }
-    ppAlert('Account created & signed in. Your free trial has started. Billing begins after the 7-day trial.');
+    ppAlert('Account created & signed in. Please subscribe to continue.');
     location.href = '/subscribe.html';
   } catch (e) {
     const msg = e.code === 'auth/email-already-in-use'

--- a/public/script.js
+++ b/public/script.js
@@ -82,7 +82,7 @@ async function safeFetchJson(url, opts = {}) {
 
     if (r.ok) {
       const me = await r.json();
-      if (me?.subscriber || me?.trialActive) {
+      if (me?.subscriber) {
         if (appEl) appEl.hidden = false;
         return;
       }

--- a/server.js
+++ b/server.js
@@ -141,24 +141,16 @@ function requireAuth(req, res, next) {
   next();
 }
 
-// Allow access if the user is a subscriber OR has an active trial
-async function requireSubOrTrial(req, res, next) {
+// Allow access only if the user is a subscriber
+async function requireSubscriber(req, res, next) {
   if (!req.user?.uid) return res.status(401).json({ error: 'Sign in required' });
   try {
     const snap = await db.doc(`users/${req.user.uid}`).get();
-    if (snap.exists) {
-      const data = snap.data() || {};
-      const subscriber = !!data.subscriber;
-      const trialEnd = data.trialEnds instanceof admin.firestore.Timestamp
-        ? data.trialEnds.toDate()
-        : data.trialEnds ? new Date(data.trialEnds) : null;
-      const trialActive = trialEnd && trialEnd.getTime() > Date.now();
-      if (subscriber || trialActive) return next();
-    }
+    if (snap.exists && !!(snap.data()?.subscriber)) return next();
   } catch (e) {
-    console.warn('requireSubOrTrial read failed:', e.message);
+    console.warn('requireSubscriber read failed:', e.message);
   }
-  return res.status(402).json({ error: 'Subscription or trial required' });
+  return res.status(402).json({ error: 'Subscription required' });
 }
 
 app.use(authOptional);
@@ -178,20 +170,12 @@ app.get('/api/me', requireAuth, async (req, res) => {
   res.set('Expires', '0');
   const { uid, email } = req.user || {};
   let subscriber = false;
-  let trialEnds = null;
-  let trialActive = false;
 
   try {
     const snap = await db.doc(`users/${uid}`).get();
     if (snap.exists) {
       const data = snap.data() || {};
       subscriber = !!data.subscriber;
-      if (data.trialEnds instanceof admin.firestore.Timestamp) {
-        trialEnds = data.trialEnds.toDate();
-      } else if (data.trialEnds) {
-        trialEnds = new Date(data.trialEnds);
-      }
-      if (trialEnds) trialActive = trialEnds.getTime() > Date.now();
     }
   } catch (e) {
     console.warn('me: firestore read failed', e.message);
@@ -200,33 +184,8 @@ app.get('/api/me', requireAuth, async (req, res) => {
   res.json({
     uid,
     email,
-    subscriber,
-    trialEnds: trialEnds ? trialEnds.toISOString() : null,
-    trialActive
+    subscriber
   });
-});
-
-// Set up a 7-day trial for the signed-in user (if not already present)
-app.post('/api/trial', requireAuth, async (req, res) => {
-  try {
-    const { uid } = req.user;
-    const ref = db.doc(`users/${uid}`);
-    const snap = await ref.get();
-    let trialEnds;
-    if (snap.exists && snap.data()?.trialEnds) {
-      const existing = snap.data().trialEnds;
-      trialEnds = existing instanceof admin.firestore.Timestamp ? existing.toDate() : new Date(existing);
-    } else {
-      const now = admin.firestore.Timestamp.now();
-      const endTs = admin.firestore.Timestamp.fromMillis(now.toMillis() + 7 * 24 * 60 * 60 * 1000);
-      await ref.set({ trialEnds: endTs }, { merge: true });
-      trialEnds = endTs.toDate();
-    }
-    res.json({ trialEnds: trialEnds.toISOString(), trialActive: trialEnds.getTime() > Date.now() });
-  } catch (e) {
-    console.error('trial start failed:', e);
-    res.status(500).json({ error: e.message || 'Could not start trial' });
-  }
 });
 
 // ---- DEBUG: show masked PayFast/Firebase envs (no secrets) --------------------
@@ -718,7 +677,7 @@ app.get('/api/versesCount', (req, res) => {
 });
 
 // 7️⃣ Endpoint: fetch bible text (single or multi-chapter)
-app.post('/api/verses', requireSubOrTrial, (req, res) => {
+app.post('/api/verses', requireSubscriber, (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse } = req.body;
     if (!book || !startChapter || !startVerse) {
@@ -738,7 +697,7 @@ app.post('/api/verses', requireSubOrTrial, (req, res) => {
 });
 
 // 8️⃣ Endpoint: translate into Afrikaans
-app.post('/api/translate', requireSubOrTrial, async (req, res) => {
+app.post('/api/translate', requireSubscriber, async (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse } = req.body;
     if (!book || !startChapter || !startVerse) {
@@ -764,7 +723,7 @@ app.post('/api/translate', requireSubOrTrial, async (req, res) => {
   }
 });
 // 9️⃣ Endpoint: AI-only commentary
-app.post('/api/commentary', requireSubOrTrial, async (req, res) => {
+app.post('/api/commentary', requireSubscriber, async (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse, tone, level, lang } = req.body;
     if (!book || !startChapter || !startVerse) {
@@ -805,7 +764,7 @@ const passageRef = `${afRefBook} ${startChapter}:${startVerse}-${endChapter || s
   }
 });
 // 9.5️⃣ Endpoint: AI-only devotion
-app.post('/api/devotion',  requireSubOrTrial, async (req, res) => {
+app.post('/api/devotion',  requireSubscriber, async (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse, lang } = req.body;
     if (!book || !startChapter || !startVerse) {
@@ -854,7 +813,7 @@ ${scripture}`;
 
 
 // 🔟 Endpoint: AI-only prayer
-app.post('/api/prayer',    requireSubOrTrial, async (req, res) => {
+app.post('/api/prayer',    requireSubscriber, async (req, res) => {
   try {
     const { book, startChapter, startVerse, endChapter, endVerse, lang } = req.body;
     if (!book || !startChapter || !startVerse) {


### PR DESCRIPTION
## Summary
- Replace trial-aware middleware with subscriber-only check
- Remove trial info and route from server API
- Update frontend auth flows for subscription-only access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af26120050832599d29a2ec024e8f2