### PR TITLE
Allow PayFast sandbox in CSP

### DIFF
--- a/server.js
+++ b/server.js
@@ -90,6 +90,7 @@ app.use(helmet({
         "'self'",
         "https://preach-point-login.vercel.app",
         "https://www.payfast.co.za",
+        "https://sandbox.payfast.co.za",
         "https://identitytoolkit.googleapis.com",
         "https://securetoken.googleapis.com",
         "https://www.googleapis.com",
@@ -97,7 +98,7 @@ app.use(helmet({
         "https://firestore.googleapis.com",
         "https://*.firebaseio.com"
       ],
-      frameSrc:   ["https://www.payfast.co.za"],
+      frameSrc:   ["https://www.payfast.co.za", "https://sandbox.payfast.co.za"],
       formAction: [
         "'self'",
         "https://www.payfast.co.za",

--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.gstatic.com https://www.googletagmanager.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.vercel.app https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firestore.googleapis.com https://firebaseinstallations.googleapis.com https://firebasestorage.googleapis.com https://www.googleapis.com https://*.googleapis.com https://www.payfast.co.za; frame-ancestors 'self'; base-uri 'self'; form-action 'self' https://www.payfast.co.za https://sandbox.payfast.co.za;"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.gstatic.com https://www.googletagmanager.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://*.vercel.app https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firestore.googleapis.com https://firebaseinstallations.googleapis.com https://firebasestorage.googleapis.com https://www.googleapis.com https://*.googleapis.com https://www.payfast.co.za https://sandbox.payfast.co.za; frame-src https://www.payfast.co.za https://sandbox.payfast.co.za; frame-ancestors 'self'; base-uri 'self'; form-action 'self' https://www.payfast.co.za https://sandbox.payfast.co.za;"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- allow PayFast sandbox URL for client connections and frames
- expose PayFast sandbox in Vercel CDN CSP header

## Testing
- `npm test`
- `vercel deploy --prod` *(fails: No existing credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_68af307be07483259207c54e331fe09f