### PR TITLE
feat: poll subscription status on success page

### DIFF
--- a/public/subscribe/success.html
+++ b/public/subscribe/success.html
@@ -14,7 +14,29 @@
 
     <h1>Thank you!</h1>
     <p>Your payment was received.</p>
+    <p id="status">Verifying payment…</p>
     <button onclick="location.href='/'">Back to Preach Point</button>
   </div>
+  <script>
+    async function checkSubscription() {
+      try {
+        const res = await fetch('/api/me');
+        if (res.ok) {
+          const data = await res.json();
+          if (data.subscriber) {
+            window.location.href = '/index.html';
+            return;
+          }
+        }
+      } catch (e) {
+        // Ignore network errors and keep polling
+      }
+      setTimeout(checkSubscription, 2000);
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      checkSubscription();
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- poll `/api/me` from the subscription success page and redirect to the app once `subscriber` is true
- show a temporary "Verifying payment…" message while waiting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af5d1fea248325a6eb263cd8d11898