### PR TITLE
Allow inline scripts in CSP

### DIFF
--- a/server.js
+++ b/server.js
@@ -81,7 +81,7 @@ app.use(helmet({
   contentSecurityPolicy: {
     directives: {
       defaultSrc: ["'self'"],
-      scriptSrc:  ["'self'", "https://www.gstatic.com", "https://www.googletagmanager.com", "https://cdnjs.cloudflare.com"],
+      scriptSrc:  ["'self'", "'unsafe-inline'", "'unsafe-eval'", "https://www.gstatic.com", "https://www.googletagmanager.com", "https://cdnjs.cloudflare.com"],
       styleSrc:   ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
       fontSrc:    ["'self'", "https://fonts.gstatic.com", "data:"],
       imgSrc:     ["'self'", "data:", "https://*"],


### PR DESCRIPTION
## Summary
- permit inline and eval scripts in Helmet CSP to match deployment config

## Testing
- `npm test`
- `curl -I http://localhost:3000/subscribe.html`


------
https://chatgpt.com/codex/tasks/task_e_68b0060df2d48325846a98744af143de